### PR TITLE
Remove documentation for Download All functionality

### DIFF
--- a/markdown-docs/vertex/manual.en.md
+++ b/markdown-docs/vertex/manual.en.md
@@ -310,22 +310,6 @@ Enhanced download queue functionality is now available on Google Chrome browser.
 	- **Data Download** is used to download multiple products, with either the *Download Python Script (.py)* option or *Metalink (metalink)* file option.
 	- **Metadata Download** is used to export the contents of the download queue to a *CSV*, *KML*, or *GeoJSON* file. The *KML* and *GeoJSON* files provided by this feature are compatible with the *Geographic Search Import* feature.
 
-### Google Chrome Browser
-
-Enhanced download queue functionality is available on Google Chrome browser. Please note, this improved functionality is not supported while using incognito mode.
-
-- Click on the **cart icon** in the header, labeled **Downloads** to open your download queue.
-	- Next to each file, you may click the **cloud** icon to begin the download.
-		- As the download begins, a progress indicator lists the percentage downloaded. Once the dowload has completed, the icon appears as a **check mark** to indicate the file has been downloaded.
-		- While the file is downloading, you may click the progress indicator to stop the download.
-	- Under **Data Download**, you may select **Download All**. This will download 3 files at a time until all products in your cart have been downloaded. The same progress indicators and checkmarks will be displayed to let you know the status of each download in your queue.
-		- When you click **Download All**, a dialog box will appear:
-			1. Navigate to the folder where you wish to save the files and click *Select*.
-			2. Click *View Files* to allow the download to continue. 
-			3. Click *Save Changes* to save your download folder preferences. This will persist as long as the Vertex browser window remains open.
-	- If you **Clear** the products in your queue, the download progress and completion indicators will reset. You may add the products to your queue again if desired.
-	- *Note*: You must be signed in to download files. If you are not signed in, when you click to begin a download, you will be redirected to the sign in page first.
-
 ## Other Vertex Options
 
 - In the top left corner of the map, there are buttons that allow you to change your **map view**, **zoom**, and **layers**. *Note:* Available map controls vary by search type.

--- a/markdown-docs/vertex/manual.es.md
+++ b/markdown-docs/vertex/manual.es.md
@@ -310,22 +310,6 @@ La funcionalidad mejorada de la lista de descargas ahora está disponible en el 
   - **Descarga de Datos** se utiliza para descargar múltiples productos, con la opción *Descargar Script de Python (.py)* o la opción de archivo *Metalink (metalink)*.
   - **Descarga de Metadatos** se utiliza para exportar el contenido de la lista de descargas a un archivo *CSV*, *KML* o *GeoJSON*. Los archivos *KML* y *GeoJSON* proporcionados por esta función son compatibles con la función de *Importación de Búsqueda Geográfica*.
 
-### Navegador Google Chrome
-
-La funcionalidad mejorada de la lista de descargas está disponible en el navegador Google Chrome. Tenga en cuenta que esta funcionalidad mejorada no es compatible cuando se usa el modo incógnito.
-
-- Haga clic en el **icono del carrito** en el encabezado, etiquetado como **Descargas** para abrir su lista de descargas.
-  - Junto a cada archivo, puede hacer clic en el icono de **nube** para comenzar la descarga.
-    - Al comenzar la descarga, un indicador de progreso muestra el porcentaje descargado. Una vez que la descarga se haya completado, el icono aparecerá como una **marca de verificación** para indicar que el archivo ha sido descargado.
-    - Mientras el archivo se está descargando, puede hacer clic en el indicador de progreso para detener la descarga.
-  - Bajo **Descarga de Datos**, puede seleccionar **Descargar Todo**. Esto descargará 3 archivos a la vez hasta que todos los productos en su carrito se hayan descargado. Los mismos indicadores de progreso y marcas de verificación se mostrarán para informarle el estado de cada descarga en su lista.
-    - Cuando haga clic en **Descargar Todo**, aparecerá un cuadro de diálogo:
-      1. Navegue a la carpeta donde desea guardar los archivos y haga clic en *Seleccionar*.
-      2. Haga clic en *Ver Archivos* para permitir que la descarga continúe.
-      3. Haga clic en *Guardar Cambios* para guardar sus preferencias de carpeta de descarga. Esto persistirá mientras la ventana del navegador Vertex permanezca abierta.
-  - Si **Borra** los productos en su lista, los indicadores de progreso y finalización de la descarga se restablecerán. Puede agregar los productos a su lista nuevamente si lo desea.
-  - *Nota*: Debe iniciar sesión para descargar archivos. Si no ha iniciado sesión, cuando haga clic para comenzar una descarga, será redirigido primero a la página de inicio de sesión.
-
 ## Otras Opciones de Vertex
 
 - En la esquina superior izquierda del mapa, hay botones que le permiten cambiar su **vista del mapa**, **zoom** y **capas**. *Nota:* Los controles del mapa disponibles varían según el tipo de búsqueda.


### PR DESCRIPTION
I've removed the sections about the Download All function, but am not sure what else needs to happen for the release workflow.